### PR TITLE
Kyutai streaming implementation, plus a mouse listener

### DIFF
--- a/docs/STREAMING_STT.md
+++ b/docs/STREAMING_STT.md
@@ -1,0 +1,147 @@
+# Streaming STT (Kyutai Delayed-Streams-Modeling)
+
+This guide covers setting up VoiceType's real-time streaming speech-to-text mode using Kyutai's delayed-streams-modeling (DSM) Rust server. In this mode, words are typed into the focused application **as you speak**, while holding a push-to-talk button.
+
+## Prerequisites
+
+- Linux with X11 (tested on Ubuntu with GNOME)
+- Python 3.11+
+- A working microphone
+- The Kyutai DSM Rust server (see below)
+
+## 1. Set Up the Kyutai DSM Rust Server
+
+Follow the install and setup instructions at [kyutai-labs/delayed-streams-modeling](https://github.com/kyutai-labs/delayed-streams-modeling/) to build and run the Rust-based streaming server.
+
+Once running, the server should be reachable at `ws://127.0.0.1:8080/api/asr-streaming` (default).
+
+> **Tip:** For auto-start on boot, create a systemd service for the Rust server.
+
+## 2. Install VoiceType
+
+```bash
+cd voiceType
+git submodule update --init --recursive
+uv sync
+uv run python -m voicetype install
+```
+
+The installer creates a systemd user service that auto-starts on login.
+
+## 3. Configure the Pipeline
+
+VoiceType loads settings from (in order):
+1. `./settings.toml`
+2. `~/.config/voicetype/settings.toml`
+3. `/etc/voicetype/settings.toml`
+
+If no file exists, built-in defaults are used. To customize, create a `settings.toml`:
+
+```toml
+[stage_configs.StreamingSTT]
+server_url = "ws://127.0.0.1:8080"   # Kyutai DSM server URL
+api_key = "public_token"              # Server API key
+# sample_rate = 24000                 # Must match server (default: 24000)
+# block_size = 1920                   # 80ms chunks at 24kHz (default: 1920)
+# max_duration = 120                  # Max streaming seconds (default: 120)
+# silence_flush_duration = 1.5        # Silence sent after PTT release to flush last words (default: 1.5)
+# drain_timeout = 2.0                 # Wait for final server responses (default: 2.0)
+# keyboard_backend = "auto"           # auto, pynput, wtype, or eitype
+# char_delay = 0.001                  # Inter-character delay for pynput backend
+# device_name = "My Microphone"       # Specific audio input device (default: system default)
+
+[[pipelines]]
+name = "streaming"
+enabled = true
+hotkey = "<pause>"                    # See "Hotkey Options" below
+stages = ["StreamingSTT"]
+```
+
+## 4. Hotkey Options
+
+### Keyboard keys
+
+Standard pynput key names work:
+
+```toml
+hotkey = "<pause>"          # Pause/Break key
+hotkey = "<f12>"            # F12
+hotkey = "<ctrl>+<shift>+s" # Modifier combo
+```
+
+### Mouse buttons
+
+Mouse buttons are supported with the `<mouseN>` syntax:
+
+```toml
+hotkey = "<mouse8>"    # Thumb back button (common for multi-button mice)
+hotkey = "<mouse9>"    # Thumb forward button
+hotkey = "<mouse20>"   # Remapped button (see below)
+```
+
+Mouse buttons can also be combined with keyboard modifiers: `<ctrl>+<mouse8>`.
+
+### Remapping mouse buttons (X11)
+
+By default, mouse button 8 triggers "browser back" in most applications. To disable that while keeping the button usable for VoiceType, remap it via `xinput` to a high unused button number:
+
+```bash
+# Find your mouse device name
+xinput list | grep -i mouse
+
+# Check current button map
+xinput get-button-map "Your Mouse Name"
+
+# Remap button 8 to button 20 (no default action)
+xinput set-button-map "Your Mouse Name" 1 2 3 4 5 6 7 20 9 10 11 12 13 14 15 16 17 18 19 20
+```
+
+Then set your hotkey to match the remapped number:
+
+```toml
+hotkey = "<mouse20>"
+```
+
+To make the remap persistent across reboots, add the `xinput set-button-map` command to `~/.xprofile`:
+
+```bash
+echo 'xinput set-button-map "Your Mouse Name" 1 2 3 4 5 6 7 20 9 10 11 12 13 14 15 16 17 18 19 20' >> ~/.xprofile
+```
+
+## 5. Usage
+
+1. Start the Kyutai DSM Rust server
+2. Start VoiceType (or let the systemd service handle it):
+   ```bash
+   uv run python -m voicetype
+   ```
+3. **Hold** the PTT button and speak — words appear in the focused app in real-time
+4. **Release** the button — the mic cuts, a brief silence flush ensures the last word(s) come through, then the session ends
+
+### Service management
+
+```bash
+voicetype status    # Check if running
+voicetype restart   # Restart after config changes
+voicetype stop      # Stop the service
+voicetype start     # Start the service
+```
+
+Or use systemctl directly:
+
+```bash
+systemctl --user restart app-io.github.voicetype.VoiceType.service
+journalctl --user -u app-io.github.voicetype.VoiceType.service -f   # Follow logs
+```
+
+## How It Works
+
+The `StreamingSTT` stage runs a single-stage pipeline that handles everything concurrently:
+
+1. Opens a WebSocket connection to the Kyutai DSM server
+2. Captures audio from the microphone (24kHz, mono, float32, 80ms chunks)
+3. Streams audio as MessagePack-encoded messages to the server
+4. Receives word-by-word transcriptions and types each word immediately via the keyboard backend
+5. On PTT release: stops the mic, sends silence to flush the server's pipeline, waits briefly for final words, then closes cleanly
+
+The server also provides built-in voice activity detection (VAD), so no separate VAD setup is needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ audioop-lts = "*"  # for pydub compatibility with Python 3.13+ # necessary until
 playsound3 = "*" # for sound
 soundfile = "*"  # for sound recording
 sounddevice = "*"  # for detecting input devices and recording sound
+msgpack = "*"  # for Kyutai DSM streaming STT protocol
+websockets = "*"  # for Kyutai DSM streaming STT connection
 pydantic-settings = "*"
 toml = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,27 @@ classifiers = [
 ]
 dynamic = ["version"]
 
+dependencies = [
+    "loguru",
+    "pystray",
+    "prompt_toolkit",
+    "pydub",
+    "audioop-lts; python_version >= '3.13'",
+    "playsound3",
+    "soundfile",
+    "sounddevice",
+    "msgpack",
+    "websockets",
+    "pydantic-settings",
+    "toml",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp",
+    "opentelemetry-instrumentation",
+    "numpy",
+    "six",
+]
+
 [project.scripts]
 voicetype = "voicetype.install:main"
 run-voicetype = "voicetype.__main__:main"

--- a/settings.example.toml
+++ b/settings.example.toml
@@ -214,7 +214,26 @@ stages = [
 #     "TypeText_default",
 # ]
 
-# Example 4: Pipeline with multiple instances of same stage
+# Example 4: Streaming STT pipeline (Kyutai DSM server)
+# Types words in real-time as you speak while PTT is held.
+# Requires the Kyutai delayed-streams-modeling Rust server running.
+# [[pipelines]]
+# name = "streaming"
+# enabled = false
+# hotkey = "<pause>"
+# stages = ["StreamingSTT_default"]
+
+# [stage_configs.StreamingSTT_default]
+# stage_class = "StreamingSTT"
+# server_url = "ws://127.0.0.1:8080"  # Kyutai DSM Rust server URL
+# api_key = "public_token"
+# # sample_rate = 24000  # Must match server expectation
+# # block_size = 1920  # 80ms audio blocks at 24kHz
+# # max_duration = 120  # Max streaming duration in seconds
+# # keyboard_backend = "auto"
+# # char_delay = 0.001
+
+# Example 5: Pipeline with multiple instances of same stage
 # To use a stage twice with different configs, create separate named instances
 # [stage_configs.CorrectTypos_slang]
 # stage_class = "CorrectTypos"
@@ -246,6 +265,7 @@ stages = [
 #   - Transcribe: Converts audio to text using speech recognition
 #   - CorrectTypos: Corrects configured typos and common speech-to-text errors
 #   - LLMAgent: Processes text through an LLM agent (local or remote)
+#   - StreamingSTT: Streams audio to Kyutai DSM server, types words in real-time
 #   - TypeText: Types the transcribed text at the current cursor position
 #
 # Hotkey Format:

--- a/voicetype/hotkey_listener/pynput_hotkey_listener.py
+++ b/voicetype/hotkey_listener/pynput_hotkey_listener.py
@@ -1,5 +1,6 @@
+import re
 import threading
-from typing import Callable, Dict, Optional, Set
+from typing import Any, Callable, Dict, Optional, Set
 
 from loguru import logger
 
@@ -8,14 +9,86 @@ from voicetype._vendor import pynput
 from .hotkey_listener import HotkeyListener
 
 keyboard = pynput.keyboard
+mouse = pynput.mouse
+
+_MOUSE_TOKEN_RE = re.compile(r"<mouse(\d+)>", re.IGNORECASE)
+
+
+class MouseButton:
+    """Sentinel representing a mouse button for use in hotkey combo sets.
+
+    Lives alongside pynput keyboard.Key / keyboard.KeyCode objects in the
+    shared _pressed_keys set.
+    """
+
+    __slots__ = ("number",)
+
+    def __init__(self, number: int):
+        self.number = number
+
+    def __eq__(self, other):
+        return isinstance(other, MouseButton) and self.number == other.number
+
+    def __hash__(self):
+        return hash(("MouseButton", self.number))
+
+    def __repr__(self):
+        return f"<mouse{self.number}>"
+
+
+def _pynput_button_to_number(button: Any) -> Optional[int]:
+    """Extract the integer button number from a pynput mouse.Button value."""
+    # pynput Button enum: left=1, middle=2, right=3 on X11
+    # Extra buttons (8, 9, ...) are created dynamically with matching values
+    try:
+        val = button.value
+        if isinstance(val, int):
+            return val
+    except AttributeError:
+        pass
+    # Fallback: parse digits from the name (e.g. "x1" -> 1, "button8" -> 8)
+    name = getattr(button, "name", str(button))
+    match = re.search(r"(\d+)", name)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _parse_hotkey(hotkey_str: str):
+    """Parse a hotkey string that may contain <mouseN> tokens.
+
+    Returns:
+        (combo_set, has_mouse_buttons) where combo_set contains a mix of
+        keyboard.Key/KeyCode objects and MouseButton sentinels.
+    """
+    mouse_buttons: Set[MouseButton] = set()
+    keyboard_tokens = []
+
+    for token in hotkey_str.split("+"):
+        token = token.strip()
+        match = _MOUSE_TOKEN_RE.fullmatch(token)
+        if match:
+            mouse_buttons.add(MouseButton(int(match.group(1))))
+        else:
+            keyboard_tokens.append(token)
+
+    keyboard_keys: set = set()
+    if keyboard_tokens:
+        keyboard_str = "+".join(keyboard_tokens)
+        keyboard_keys = set(keyboard.HotKey.parse(keyboard_str))
+
+    return keyboard_keys | mouse_buttons, bool(mouse_buttons)
 
 
 class PynputHotkeyListener(HotkeyListener):
     """Cross-platform hotkey listener implementation using pynput.
 
-    This class handles keyboard events to detect when specific hotkey
-    combinations are pressed and released. Supports multiple hotkeys
-    simultaneously. Works on Windows, Linux (X11), and macOS.
+    This class handles keyboard and mouse button events to detect when
+    specific hotkey combinations are pressed and released. Supports
+    multiple hotkeys simultaneously, including mouse buttons via the
+    <mouseN> syntax (e.g. <mouse8> for thumb button).
+
+    Works on Windows, Linux (X11), and macOS.
     """
 
     def __init__(
@@ -24,35 +97,43 @@ class PynputHotkeyListener(HotkeyListener):
         on_hotkey_release: Optional[Callable[[str], None]] = None,
     ):
         super().__init__(on_hotkey_press, on_hotkey_release)
-        # hotkey_string -> parsed key set
-        self._hotkey_combos: Dict[str, Set[keyboard.Key | keyboard.KeyCode]] = {}
-        self._listener: Optional[keyboard.Listener] = None
-        self._pressed_keys: Set[keyboard.Key | keyboard.KeyCode] = set()
+        # hotkey_string -> parsed key/button set
+        self._hotkey_combos: Dict[str, set] = {}
+        self._keyboard_listener: Optional[keyboard.Listener] = None
+        self._mouse_listener: Optional[mouse.Listener] = None
+        self._pressed_keys: set = set()
         # Track press state per hotkey string
         self._hotkey_pressed: Dict[str, bool] = {}
+        self._needs_mouse: bool = False
         self._lock = threading.Lock()
 
     def add_hotkey(self, hotkey: str, name: str = "") -> None:
         try:
-            combo = set(keyboard.HotKey.parse(hotkey))
-            self._hotkey_combos[hotkey] = combo
-            self._hotkey_pressed[hotkey] = False
-            logger.info(f"Hotkey added: {hotkey} -> {combo}")
+            combo, has_mouse = _parse_hotkey(hotkey)
         except ValueError as e:
             logger.error(f"Error parsing hotkey '{hotkey}': {e}")
             raise ValueError(f"Invalid hotkey format: {hotkey}") from e
 
+        self._hotkey_combos[hotkey] = combo
+        self._hotkey_pressed[hotkey] = False
+        if has_mouse:
+            self._needs_mouse = True
+        logger.info(f"Hotkey added: {hotkey} -> {combo}")
+
     def clear_hotkeys(self) -> None:
         self._hotkey_combos.clear()
         self._hotkey_pressed.clear()
+        self._needs_mouse = False
 
-    def _on_key_press(self, key: Optional[keyboard.Key | keyboard.KeyCode]):
-        if key is None or not self._hotkey_combos:
+    # -- shared press/release logic --
+
+    def _handle_press(self, key) -> None:
+        """Common press handler for both keyboard keys and mouse buttons."""
+        if not self._hotkey_combos:
             return
 
         with self._lock:
-            canonical_key = self._listener.canonical(key)
-            self._pressed_keys.add(canonical_key)
+            self._pressed_keys.add(key)
 
             for hotkey_str, combo in self._hotkey_combos.items():
                 if not self._hotkey_pressed[hotkey_str] and combo.issubset(
@@ -62,57 +143,91 @@ class PynputHotkeyListener(HotkeyListener):
                     self._hotkey_pressed[hotkey_str] = True
                     self._trigger_hotkey_press(hotkey_str)
 
-    def _on_key_release(self, key: Optional[keyboard.Key | keyboard.KeyCode]):
-        if key is None or not self._hotkey_combos:
+    def _handle_release(self, key) -> None:
+        """Common release handler for both keyboard keys and mouse buttons."""
+        if not self._hotkey_combos:
             return
-
-        canonical_key = self._listener.canonical(key)
 
         with self._lock:
             for hotkey_str, combo in self._hotkey_combos.items():
-                if self._hotkey_pressed[hotkey_str] and canonical_key in combo:
+                if self._hotkey_pressed[hotkey_str] and key in combo:
                     any_hotkey_key_pressed = any(
-                        k in self._pressed_keys for k in combo if k != canonical_key
+                        k in self._pressed_keys for k in combo if k != key
                     )
                     if not any_hotkey_key_pressed:
                         self._hotkey_pressed[hotkey_str] = False
                         self._trigger_hotkey_release(hotkey_str)
 
-            if canonical_key in self._pressed_keys:
-                self._pressed_keys.remove(canonical_key)
+            self._pressed_keys.discard(key)
+
+    # -- keyboard callbacks --
+
+    def _on_key_press(self, key: Optional[keyboard.Key | keyboard.KeyCode]):
+        if key is None:
+            return
+        canonical_key = self._keyboard_listener.canonical(key)
+        self._handle_press(canonical_key)
+
+    def _on_key_release(self, key: Optional[keyboard.Key | keyboard.KeyCode]):
+        if key is None:
+            return
+        canonical_key = self._keyboard_listener.canonical(key)
+        self._handle_release(canonical_key)
+
+    # -- mouse callbacks --
+
+    def _on_mouse_click(self, x: int, y: int, button, pressed: bool):
+        btn_num = _pynput_button_to_number(button)
+        if btn_num is None:
+            return
+        sentinel = MouseButton(btn_num)
+        if pressed:
+            self._handle_press(sentinel)
+        else:
+            self._handle_release(sentinel)
+
+    # -- lifecycle --
 
     def start_listening(self) -> None:
-        if self._listener is not None and self._listener.is_alive():
+        if self._keyboard_listener is not None and self._keyboard_listener.is_alive():
             logger.info("Listener already running.")
             return
 
         if not self._hotkey_combos:
             raise ValueError("No hotkeys registered before starting listener.")
 
-        self._listener = keyboard.Listener(
+        self._keyboard_listener = keyboard.Listener(
             on_press=self._on_key_press,
             on_release=self._on_key_release,
         )
+        self._keyboard_listener.start()
+        logger.debug(f"Keyboard listener thread: {self._keyboard_listener.ident}")
 
-        self._listener.start()
-        logger.debug(f"Current thread: {threading.get_ident()}")
-        logger.debug(f"Listener thread: {self._listener.ident}")
-        assert (
-            threading.get_ident() != self._listener.ident
-        ), "Listener thread should not be the main thread."
-        logger.info("Pynput hotkey listener started.")
+        if self._needs_mouse:
+            self._mouse_listener = mouse.Listener(
+                on_click=self._on_mouse_click,
+            )
+            self._mouse_listener.start()
+            logger.debug(f"Mouse listener thread: {self._mouse_listener.ident}")
+            logger.info("Pynput hotkey listener started (keyboard + mouse).")
+        else:
+            logger.info("Pynput hotkey listener started (keyboard only).")
 
     def stop_listening(self) -> None:
-        if self._listener and self._listener.is_alive():
-            logger.info("Stopping pynput hotkey listener...")
-            self._listener.stop()
-            assert (
-                threading.get_ident() != self._listener.ident
-            ), "Listener thread should not be the main thread."
-            self._listener.join()
-            logger.info("Pynput hotkey listener stopped.")
+        if self._keyboard_listener and self._keyboard_listener.is_alive():
+            logger.info("Stopping pynput keyboard listener...")
+            self._keyboard_listener.stop()
+            self._keyboard_listener.join()
+            logger.info("Pynput keyboard listener stopped.")
 
-        self._listener = None
+        if self._mouse_listener and self._mouse_listener.is_alive():
+            logger.info("Stopping pynput mouse listener...")
+            self._mouse_listener.stop()
+            self._mouse_listener.join()
+            logger.info("Pynput mouse listener stopped.")
+
+        self._keyboard_listener = None
+        self._mouse_listener = None
         self._pressed_keys.clear()
         for k in self._hotkey_pressed:
             self._hotkey_pressed[k] = False

--- a/voicetype/pipeline/stages/__init__.py
+++ b/voicetype/pipeline/stages/__init__.py
@@ -12,6 +12,7 @@ from .correct_typos import CorrectTypos
 from .llm_agent import LLMAgent
 from .record_audio import RecordAudio
 from .run_command import RunCommand
+from .streaming_stt import StreamingSTT
 from .transcribe import Transcribe
 from .type_text import TypeText
 
@@ -21,5 +22,6 @@ __all__ = [
     "CorrectTypos",
     "LLMAgent",
     "RunCommand",
+    "StreamingSTT",
     "TypeText",
 ]

--- a/voicetype/pipeline/stages/streaming_stt.py
+++ b/voicetype/pipeline/stages/streaming_stt.py
@@ -49,6 +49,16 @@ class StreamingSTTConfig(BaseModel):
         gt=0,
         description="Maximum streaming duration in seconds",
     )
+    drain_timeout: float = Field(
+        default=2.0,
+        gt=0,
+        description="Seconds to wait for final words from server after PTT release",
+    )
+    silence_flush_duration: float = Field(
+        default=1.5,
+        gt=0,
+        description="Seconds of silence to send after PTT release to flush server pipeline",
+    )
     keyboard_backend: str = Field(
         default="auto",
         description="Keyboard backend to use: auto, pynput, wtype, or eitype",
@@ -137,26 +147,56 @@ class StreamingSTT(PipelineStage[None, None]):
             logger.warning("StreamingSTT: WebSocket closed while sending")
         except asyncio.CancelledError:
             pass
+        logger.debug("StreamingSTT: send loop ended")
 
-    async def _receive_and_type(self, websocket, stop: asyncio.Event):
-        """Receive transcription messages and type words as they arrive."""
+    async def _send_silence(self, websocket):
+        """Send silence chunks to flush the server's internal pipeline.
+
+        Streaming models need continued audio input to process and emit the
+        final word(s). After the mic stops, we send silence so the model has
+        enough context to finalize.
+        """
+        silence = [0.0] * self.cfg.block_size
+        num_chunks = int(
+            self.cfg.silence_flush_duration * self.cfg.sample_rate / self.cfg.block_size
+        )
+        chunk_interval = self.cfg.block_size / self.cfg.sample_rate
+
+        logger.debug(f"StreamingSTT: sending {num_chunks} silence chunks to flush server")
+        try:
+            for _ in range(num_chunks):
+                msg = msgpack.packb(
+                    {"type": "Audio", "pcm": silence},
+                    use_bin_type=True,
+                    use_single_float=True,
+                )
+                await websocket.send(msg)
+                await asyncio.sleep(chunk_interval)
+        except websockets.ConnectionClosed:
+            logger.debug("StreamingSTT: WebSocket closed during silence flush")
+        logger.debug("StreamingSTT: silence flush done")
+
+    async def _receive_and_type(self, websocket):
+        """Receive transcription messages and type words as they arrive.
+
+        Runs until the websocket is closed or the task is cancelled.
+        """
         try:
             logger.debug("StreamingSTT: receive loop started")
             async for message in websocket:
-                if stop.is_set():
-                    break
                 data = msgpack.unpackb(message, raw=False)
                 if data["type"] == "Word":
                     word = data["text"]
                     logger.debug(f"StreamingSTT: received word: {word}")
                     self.backend.type_text(word + " ")
         except websockets.ConnectionClosed:
-            logger.warning("StreamingSTT: WebSocket closed while receiving")
+            logger.debug("StreamingSTT: WebSocket closed, receive loop done")
         except asyncio.CancelledError:
             pass
+        logger.debug("StreamingSTT: receive loop ended")
 
-    async def _watch_for_release(self, context: PipelineContext, stop: asyncio.Event):
-        """Watch for PTT release or cancellation and signal stop."""
+    async def _wait_for_release(self, context: PipelineContext):
+        """Block until PTT release or cancellation. Returns when button is released."""
         loop = asyncio.get_event_loop()
 
         def _wait():
@@ -166,14 +206,24 @@ class StreamingSTT(PipelineStage[None, None]):
                 context.cancel_requested.wait(timeout=self.cfg.max_duration)
 
         await loop.run_in_executor(None, _wait)
-        stop.set()
-        logger.debug("StreamingSTT: stop signal set (PTT released or timeout)")
 
     async def _run_streaming(self, context: PipelineContext):
-        """Main async entry point that orchestrates audio streaming and typing."""
-        stop = asyncio.Event()
+        """Main async entry point that orchestrates audio streaming and typing.
+
+        Lifecycle:
+        1. Open mic + websocket, start send/receive tasks
+        2. Wait for PTT release
+        3. Stop mic and send task immediately (no more audio)
+        4. Keep receive task alive for drain_timeout to collect final words
+        5. Close websocket cleanly
+        """
+        stop_sending = asyncio.Event()
         audio_queue: asyncio.Queue = asyncio.Queue()
         loop = asyncio.get_event_loop()
+
+        # We manage the audio stream explicitly so we can stop it on PTT release
+        # while keeping the websocket open for draining.
+        audio_stream = None
 
         def audio_callback(indata, frames, time_info, status):
             if status:
@@ -185,31 +235,59 @@ class StreamingSTT(PipelineStage[None, None]):
         url = f"{self.cfg.server_url}/api/asr-streaming"
         headers = {"kyutai-api-key": self.cfg.api_key}
 
-        with sd.InputStream(
-            samplerate=self.cfg.sample_rate,
-            channels=1,
-            dtype="float32",
-            callback=audio_callback,
-            blocksize=self.cfg.block_size,
-            device=self.device_id,
-        ):
-            async with websockets.connect(url, additional_headers=headers) as ws:
-                logger.info("StreamingSTT: connected to server, streaming started")
-                context.icon_controller.set_icon("recording")
+        async with websockets.connect(url, additional_headers=headers) as ws:
+            logger.info("StreamingSTT: connected to server, streaming started")
+            context.icon_controller.set_icon("recording")
 
-                send_task = asyncio.create_task(self._send_audio(ws, audio_queue, stop))
-                recv_task = asyncio.create_task(self._receive_and_type(ws, stop))
-                watch_task = asyncio.create_task(self._watch_for_release(context, stop))
+            # Start the audio stream
+            audio_stream = sd.InputStream(
+                samplerate=self.cfg.sample_rate,
+                channels=1,
+                dtype="float32",
+                callback=audio_callback,
+                blocksize=self.cfg.block_size,
+                device=self.device_id,
+            )
+            audio_stream.start()
 
-                # Wait for the release watcher to finish (PTT released or timeout)
-                await watch_task
+            send_task = asyncio.create_task(self._send_audio(ws, audio_queue, stop_sending))
+            recv_task = asyncio.create_task(self._receive_and_type(ws))
 
-                # Cancel the send/receive tasks
-                send_task.cancel()
-                recv_task.cancel()
+            try:
+                # Phase 1: stream audio while PTT is held
+                await self._wait_for_release(context)
+                logger.debug("StreamingSTT: PTT released, stopping mic and send")
 
-                # Wait for them to finish cancellation
-                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                # Phase 2: cut mic, then send silence to flush server pipeline
+                audio_stream.stop()
+                audio_stream.close()
+                audio_stream = None
+                stop_sending.set()
+                await send_task
+                await self._send_silence(ws)
+
+                # Phase 3: drain remaining words from server
+                logger.debug(
+                    f"StreamingSTT: draining final words (timeout={self.cfg.drain_timeout}s)"
+                )
+                context.icon_controller.set_icon("processing")
+                try:
+                    await asyncio.wait_for(recv_task, timeout=self.cfg.drain_timeout)
+                except asyncio.TimeoutError:
+                    logger.debug("StreamingSTT: drain timeout reached")
+                    recv_task.cancel()
+                    await asyncio.gather(recv_task, return_exceptions=True)
+            finally:
+                # Ensure cleanup if something went wrong
+                if audio_stream is not None:
+                    audio_stream.stop()
+                    audio_stream.close()
+                if not send_task.done():
+                    send_task.cancel()
+                    await asyncio.gather(send_task, return_exceptions=True)
+                if not recv_task.done():
+                    recv_task.cancel()
+                    await asyncio.gather(recv_task, return_exceptions=True)
 
         logger.info("StreamingSTT: streaming stopped")
 

--- a/voicetype/pipeline/stages/streaming_stt.py
+++ b/voicetype/pipeline/stages/streaming_stt.py
@@ -1,0 +1,230 @@
+"""Streaming speech-to-text stage using Kyutai's delayed-streams-modeling server.
+
+This stage captures audio from the microphone, streams it to a Kyutai DSM Rust
+server via WebSocket, and types transcribed words in real-time as they arrive.
+All three operations (capture, stream, type) run concurrently while the PTT
+button is held.
+"""
+
+import asyncio
+import threading
+from typing import Optional
+
+import msgpack
+import numpy as np
+import sounddevice as sd
+import websockets
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from voicetype.pipeline import Resource
+from voicetype.pipeline.context import PipelineContext
+from voicetype.pipeline.stage_registry import STAGE_REGISTRY, PipelineStage
+from voicetype.pipeline.stages.keyboard_backends import create_keyboard_backend
+
+
+class StreamingSTTConfig(BaseModel):
+    """Configuration for StreamingSTT stage."""
+
+    server_url: str = Field(
+        default="ws://127.0.0.1:8080",
+        description="WebSocket URL of the Kyutai DSM Rust server (without /api/asr-streaming path)",
+    )
+    api_key: str = Field(
+        default="public_token",
+        description="API key for the Kyutai server",
+    )
+    sample_rate: int = Field(
+        default=24000,
+        gt=0,
+        description="Audio sample rate in Hz (must match server expectation)",
+    )
+    block_size: int = Field(
+        default=1920,
+        gt=0,
+        description="Audio block size in samples (1920 = 80ms at 24kHz)",
+    )
+    max_duration: float = Field(
+        default=120.0,
+        gt=0,
+        description="Maximum streaming duration in seconds",
+    )
+    keyboard_backend: str = Field(
+        default="auto",
+        description="Keyboard backend to use: auto, pynput, wtype, or eitype",
+    )
+    char_delay: float = Field(
+        default=0.001,
+        ge=0,
+        description="Delay in seconds between each character (pynput backend only)",
+    )
+    device_name: Optional[str] = Field(
+        default=None,
+        description="Optional audio device name (None for system default)",
+    )
+
+
+@STAGE_REGISTRY.register
+class StreamingSTT(PipelineStage[None, None]):
+    """Stream audio to Kyutai DSM server and type transcriptions in real-time.
+
+    Captures audio from the microphone, streams it via WebSocket to the Kyutai
+    delayed-streams-modeling Rust server, and types each transcribed word into
+    the focused application as it arrives. Runs while PTT is held; stops on
+    release.
+
+    Type signature: PipelineStage[None, None]
+    - Input: None (first stage)
+    - Output: None (handles typing internally)
+
+    Config parameters:
+    - server_url: WebSocket URL of the Kyutai DSM server (default: "ws://127.0.0.1:8080")
+    - api_key: API key for the server (default: "public_token")
+    - sample_rate: Audio sample rate in Hz (default: 24000)
+    - block_size: Audio block size in samples (default: 1920 = 80ms at 24kHz)
+    - max_duration: Maximum streaming duration in seconds (default: 120)
+    - keyboard_backend: Backend selection (default: "auto")
+    - char_delay: Delay between characters for pynput (default: 0.001)
+    - device_name: Optional audio input device name (default: system default)
+    """
+
+    required_resources = {Resource.KEYBOARD}
+
+    def __init__(self, config: dict):
+        self.cfg = StreamingSTTConfig(**config)
+        self.backend = create_keyboard_backend(
+            method=self.cfg.keyboard_backend,
+            char_delay=self.cfg.char_delay,
+        )
+        self.device_id = self._find_device_id(self.cfg.device_name)
+
+    def _find_device_id(self, device_name: Optional[str]) -> Optional[int]:
+        """Find the input device ID by name or return None for default."""
+        if not device_name:
+            return None
+
+        devices = sd.query_devices()
+        input_devices = [
+            (i, d) for i, d in enumerate(devices) if d["max_input_channels"] > 0
+        ]
+        for i, device in input_devices:
+            if device_name.lower() in device["name"].lower():
+                logger.debug(f"Found specified device: {device['name']} (ID: {i})")
+                return i
+
+        available_names = [d["name"] for _, d in input_devices]
+        raise ValueError(
+            f"Device '{device_name}' not found. Available input devices: {available_names}"
+        )
+
+    async def _send_audio(self, websocket, audio_queue: asyncio.Queue, stop: asyncio.Event):
+        """Send audio chunks from the queue to the WebSocket server."""
+        try:
+            # Drain any stale audio buffered before the connection was ready
+            while not audio_queue.empty():
+                audio_queue.get_nowait()
+
+            logger.debug("StreamingSTT: send loop started")
+            while not stop.is_set():
+                try:
+                    audio_data = await asyncio.wait_for(audio_queue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+                chunk = {"type": "Audio", "pcm": [float(x) for x in audio_data]}
+                msg = msgpack.packb(chunk, use_bin_type=True, use_single_float=True)
+                await websocket.send(msg)
+        except websockets.ConnectionClosed:
+            logger.warning("StreamingSTT: WebSocket closed while sending")
+        except asyncio.CancelledError:
+            pass
+
+    async def _receive_and_type(self, websocket, stop: asyncio.Event):
+        """Receive transcription messages and type words as they arrive."""
+        try:
+            logger.debug("StreamingSTT: receive loop started")
+            async for message in websocket:
+                if stop.is_set():
+                    break
+                data = msgpack.unpackb(message, raw=False)
+                if data["type"] == "Word":
+                    word = data["text"]
+                    logger.debug(f"StreamingSTT: received word: {word}")
+                    self.backend.type_text(word + " ")
+        except websockets.ConnectionClosed:
+            logger.warning("StreamingSTT: WebSocket closed while receiving")
+        except asyncio.CancelledError:
+            pass
+
+    async def _watch_for_release(self, context: PipelineContext, stop: asyncio.Event):
+        """Watch for PTT release or cancellation and signal stop."""
+        loop = asyncio.get_event_loop()
+
+        def _wait():
+            if context.trigger_event:
+                context.trigger_event.wait_for_completion(timeout=self.cfg.max_duration)
+            else:
+                context.cancel_requested.wait(timeout=self.cfg.max_duration)
+
+        await loop.run_in_executor(None, _wait)
+        stop.set()
+        logger.debug("StreamingSTT: stop signal set (PTT released or timeout)")
+
+    async def _run_streaming(self, context: PipelineContext):
+        """Main async entry point that orchestrates audio streaming and typing."""
+        stop = asyncio.Event()
+        audio_queue: asyncio.Queue = asyncio.Queue()
+        loop = asyncio.get_event_loop()
+
+        def audio_callback(indata, frames, time_info, status):
+            if status:
+                logger.debug(f"StreamingSTT: audio callback status: {status}")
+            loop.call_soon_threadsafe(
+                audio_queue.put_nowait, indata[:, 0].astype(np.float32).copy()
+            )
+
+        url = f"{self.cfg.server_url}/api/asr-streaming"
+        headers = {"kyutai-api-key": self.cfg.api_key}
+
+        with sd.InputStream(
+            samplerate=self.cfg.sample_rate,
+            channels=1,
+            dtype="float32",
+            callback=audio_callback,
+            blocksize=self.cfg.block_size,
+            device=self.device_id,
+        ):
+            async with websockets.connect(url, additional_headers=headers) as ws:
+                logger.info("StreamingSTT: connected to server, streaming started")
+                context.icon_controller.set_icon("recording")
+
+                send_task = asyncio.create_task(self._send_audio(ws, audio_queue, stop))
+                recv_task = asyncio.create_task(self._receive_and_type(ws, stop))
+                watch_task = asyncio.create_task(self._watch_for_release(context, stop))
+
+                # Wait for the release watcher to finish (PTT released or timeout)
+                await watch_task
+
+                # Cancel the send/receive tasks
+                send_task.cancel()
+                recv_task.cancel()
+
+                # Wait for them to finish cancellation
+                await asyncio.gather(send_task, recv_task, return_exceptions=True)
+
+        logger.info("StreamingSTT: streaming stopped")
+
+    def execute(self, input_data: None, context: PipelineContext) -> None:
+        if context.cancel_requested.is_set():
+            logger.info("StreamingSTT: cancelled before start")
+            return
+
+        try:
+            asyncio.run(self._run_streaming(context))
+        except Exception:
+            logger.exception("StreamingSTT: error during streaming")
+            context.icon_controller.set_icon("error")
+
+        context.icon_controller.set_icon("idle")
+
+    def cleanup(self):
+        pass

--- a/voicetype/settings.py
+++ b/voicetype/settings.py
@@ -60,6 +60,12 @@ class Settings(BaseSettings):
         },
         "LLMAgent": {"provider": "openai:gpt-5-mini", "trigger_keywords": ["Jarvis"]},
         "TypeText": {},
+        "StreamingSTT": {
+            "server_url": "ws://127.0.0.1:8080",
+            "api_key": "public_token",
+            "keyboard_backend": "auto",
+            "char_delay": 0.001,
+        },
     }
 
     pipelines: Optional[List[Dict[str, Any]]] = [

--- a/voicetype/settings.py
+++ b/voicetype/settings.py
@@ -72,13 +72,9 @@ class Settings(BaseSettings):
         {
             "name": "default",
             "enabled": True,
-            "hotkey": "<pause>",
+            "hotkey": "<mouse20>",
             "stages": [
-                "RecordAudio",
-                "Transcribe",
-                "CorrectTypos",
-                # "LLMAgent",  # TODO: Get this working with a local model by default so it's faster
-                "TypeText",
+                "StreamingSTT",
             ],
         }
     ]


### PR DESCRIPTION
There's actually more LoC just handling the silly mouse addition, but this way you can configure it to use <mouseN> buttons, which is more natural to me.

The streaming core is pretty simple, but I added in messier bits to tackle the fact that if you close the audio stream right when you finish talking the model may not get enough to actually finish inference over your entire phrase - so I added empty audio for 1.5sec (default) after that seems to do the trick and gave it 2sec bonus to finish running through the last couple words before closing the socket - there's likely a more elegant way where we're not stuck with hard-coded closeout timer, maybe just a smaller poll timer that refreshes each time it keeps getting something (after button down).