### PR TITLE
ci: bump pixi to v0.66.0 to match lockfile format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.39.5
+          pixi-version: v0.66.0
 
       - name: Build Windows installer
         run: pixi run -e windows-build build-windows

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.40.0
+          pixi-version: v0.66.0
           cache: true
           environments: dev
 


### PR DESCRIPTION
## Summary
- Bumps `prefix-dev/setup-pixi` pin from `v0.40.0` (tests) / `v0.39.5` (release) to `v0.66.0`, matching the version that regenerated `pixi.lock` in e50d211.
- Fixes the `lock-file not up-to-date with the project` failure on `main` — the newer pixi added a per-environment `options: pypi-prerelease-mode: ...` block that older pixi doesn't recognize, so `pixi install --locked` rejected the lockfile.

## Test plan
- [ ] Tests workflow passes on this PR (verifies the bump resolves the lockfile mismatch on the `tests.yaml` path).
- [ ] Release workflow's pixi step is exercised only on tagged releases, so it can't be validated here — confirm next release builds the Windows installer cleanly.