### PR TITLE
feat(transcribe): faster model loads — skip Hub check on cached models, optional resident model

### DIFF
--- a/settings.example.toml
+++ b/settings.example.toml
@@ -108,6 +108,12 @@ language = "en"  # Language code: "en", "es", "fr", "de", etc.
 provider = "local"
 model = "large-v3-turbo"  # Whisper model: "tiny", "base", "small", "medium", "large-v3", "large-v3-turbo"
 device = "cuda"  # Device for inference: "cuda" (GPU) or "cpu"
+# keep_loaded: keep the model resident in VRAM/RAM between transcriptions instead
+# of reloading it on every hotkey press. Recommended for "cuda" when the GPU is
+# otherwise idle (e.g. monitors driven by integrated graphics), since an idle GPU
+# drops to a low-power state where reloading the model can take 5-20s. Holds the
+# model's memory (~1-2 GB VRAM for large models) for the process lifetime.
+keep_loaded = false
 
 # Cloud transcription via LiteLLM/OpenAI (requires OPENAI_API_KEY)
 [stage_configs.Transcribe_cloud]
@@ -260,6 +266,9 @@ stages = [
 #   - "local": Uses faster-whisper for local transcription (faster, offline)
 #     - model: Whisper model size (tiny, base, small, medium, large-v3, large-v3-turbo)
 #     - device: "cuda" for GPU or "cpu" for CPU inference
+#     - keep_loaded: keep the model resident between transcriptions instead of
+#       reloading it each time (default false). Avoids multi-second reloads on an
+#       idle/low-power GPU; trades ~1-2 GB of held VRAM for large models.
 #   - "litellm": Uses cloud-based transcription (requires OPENAI_API_KEY)
 #     - model: LiteLLM model identifier (e.g., whisper-1, azure/whisper)
 #

--- a/settings.example.toml
+++ b/settings.example.toml
@@ -109,10 +109,9 @@ provider = "local"
 model = "large-v3-turbo"  # Whisper model: "tiny", "base", "small", "medium", "large-v3", "large-v3-turbo"
 device = "cuda"  # Device for inference: "cuda" (GPU) or "cpu"
 # keep_loaded: keep the model resident in VRAM/RAM between transcriptions instead
-# of reloading it on every hotkey press. Recommended for "cuda" when the GPU is
-# otherwise idle (e.g. monitors driven by integrated graphics), since an idle GPU
-# drops to a low-power state where reloading the model can take 5-20s. Holds the
-# model's memory (~1-2 GB VRAM for large models) for the process lifetime.
+# of reloading it on every hotkey press. Skips all per-press load overhead. Holds
+# the model's memory (~1-2 GB VRAM for large models) for the process lifetime.
+# Can also be toggled at runtime from the tray menu.
 keep_loaded = false
 
 # Cloud transcription via LiteLLM/OpenAI (requires OPENAI_API_KEY)
@@ -267,8 +266,8 @@ stages = [
 #     - model: Whisper model size (tiny, base, small, medium, large-v3, large-v3-turbo)
 #     - device: "cuda" for GPU or "cpu" for CPU inference
 #     - keep_loaded: keep the model resident between transcriptions instead of
-#       reloading it each time (default false). Avoids multi-second reloads on an
-#       idle/low-power GPU; trades ~1-2 GB of held VRAM for large models.
+#       reloading it each time (default false). Skips per-press load overhead;
+#       trades ~1-2 GB of held VRAM for large models. Toggleable from the tray.
 #   - "litellm": Uses cloud-based transcription (requires OPENAI_API_KEY)
 #     - model: LiteLLM model identifier (e.g., whisper-1, azure/whisper)
 #

--- a/tests/test_transcribe_keep_loaded.py
+++ b/tests/test_transcribe_keep_loaded.py
@@ -199,3 +199,61 @@ class TestRuntimeKeepLoadedToggle:
 
         assert len(created) == 1
         assert s1._preloaded_model is s2._preloaded_model
+
+
+class TestLocalFilesOnly:
+    """The loader avoids the HuggingFace Hub when the model is already cached."""
+
+    def test_uses_local_cache_without_network(self, monkeypatch):
+        import faster_whisper
+
+        calls = []
+
+        class FakeModel:
+            def __init__(self, path, **kw):
+                calls.append(kw.get("local_files_only"))
+
+        monkeypatch.setattr(faster_whisper, "WhisperModel", FakeModel)
+        transcribe_mod._create_whisper_model("tiny", "cpu", "int8", "/tmp/models")
+        # Loaded straight from cache; no second (networked) attempt.
+        assert calls == [True]
+
+    def test_falls_back_to_download_when_not_cached(self, monkeypatch):
+        import faster_whisper
+
+        try:
+            from huggingface_hub.errors import LocalEntryNotFoundError
+        except ImportError:
+            from huggingface_hub.utils import LocalEntryNotFoundError
+
+        calls = []
+
+        class FakeModel:
+            def __init__(self, path, **kw):
+                lfo = kw.get("local_files_only")
+                calls.append(lfo)
+                if lfo:
+                    raise LocalEntryNotFoundError("not cached")
+
+        monkeypatch.setattr(faster_whisper, "WhisperModel", FakeModel)
+        transcribe_mod._create_whisper_model("tiny", "cpu", "int8", "/tmp/models")
+        # First tried offline, then allowed the network download.
+        assert calls == [True, False]
+
+    def test_non_cache_error_does_not_trigger_network_retry(self, monkeypatch):
+        import faster_whisper
+
+        calls = []
+
+        class FakeModel:
+            def __init__(self, path, **kw):
+                calls.append(kw.get("local_files_only"))
+                raise RuntimeError("CUDA out of memory")
+
+        monkeypatch.setattr(faster_whisper, "WhisperModel", FakeModel)
+        with pytest.raises(RuntimeError, match="CUDA out of memory"):
+            transcribe_mod._create_whisper_model(
+                "tiny", "cuda", "float16", "/tmp/models"
+            )
+        # A CUDA error must propagate from the first attempt, not retry online.
+        assert calls == [True]

--- a/tests/test_transcribe_keep_loaded.py
+++ b/tests/test_transcribe_keep_loaded.py
@@ -1,0 +1,138 @@
+"""Tests for the resident-model (``keep_loaded``) option of the Transcribe stage.
+
+These tests patch the model constructor so they run without a GPU or the
+faster-whisper package being able to load a real model.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import voicetype.pipeline.stages.transcribe as transcribe_mod
+from voicetype.pipeline.stages.transcribe import (
+    LocalSTTRuntime,
+    Transcribe,
+    TranscribeConfig,
+)
+
+
+@pytest.fixture
+def clear_model_cache():
+    """Ensure the module-level resident-model cache is empty around each test."""
+    transcribe_mod._MODEL_CACHE.clear()
+    yield
+    transcribe_mod._MODEL_CACHE.clear()
+
+
+class TestKeepLoadedConfig:
+    """The keep_loaded flag is configurable and defaults to off."""
+
+    def test_keep_loaded_defaults_false(self):
+        assert LocalSTTRuntime().keep_loaded is False
+
+    def test_keep_loaded_settable(self):
+        runtime = LocalSTTRuntime(
+            model="large-v3-turbo", device="cuda", keep_loaded=True
+        )
+        assert runtime.keep_loaded is True
+
+    def test_keep_loaded_via_transcribe_config(self):
+        config = TranscribeConfig(
+            runtime={
+                "provider": "local",
+                "model": "tiny",
+                "device": "cpu",
+                "keep_loaded": True,
+            }
+        )
+        assert isinstance(config.runtime, LocalSTTRuntime)
+        assert config.runtime.keep_loaded is True
+
+
+class TestResidentModelCache:
+    """When keep_loaded is on, the model is loaded once and reused."""
+
+    def _local_cfg(self, keep_loaded):
+        return {
+            "runtime": {
+                "provider": "local",
+                "model": "tiny",
+                "device": "cpu",
+                "keep_loaded": keep_loaded,
+            }
+        }
+
+    def test_resident_model_loaded_once_and_reused(self, clear_model_cache):
+        created = []
+
+        def fake_create(model_path, device, compute_type, models_dir):
+            obj = object()
+            created.append(obj)
+            return obj
+
+        with patch.object(
+            transcribe_mod, "_create_whisper_model", side_effect=fake_create
+        ):
+            s1 = Transcribe(config=self._local_cfg(keep_loaded=True))
+            assert s1._model_ready.wait(timeout=10)
+            assert s1._preload_error is None
+
+            s2 = Transcribe(config=self._local_cfg(keep_loaded=True))
+            assert s2._model_ready.wait(timeout=10)
+            assert s2._preload_error is None
+
+        # Constructed exactly once; both stages share the same instance.
+        assert len(created) == 1
+        assert s1._preloaded_model is created[0]
+        assert s2._preloaded_model is s1._preloaded_model
+
+    def test_non_resident_model_loaded_each_time(self, clear_model_cache):
+        created = []
+
+        def fake_create(model_path, device, compute_type, models_dir):
+            obj = object()
+            created.append(obj)
+            return obj
+
+        with patch.object(
+            transcribe_mod, "_create_whisper_model", side_effect=fake_create
+        ):
+            s1 = Transcribe(config=self._local_cfg(keep_loaded=False))
+            assert s1._model_ready.wait(timeout=10)
+            s2 = Transcribe(config=self._local_cfg(keep_loaded=False))
+            assert s2._model_ready.wait(timeout=10)
+
+        assert len(created) == 2
+        assert s1._preloaded_model is not s2._preloaded_model
+        # Nothing cached when keep_loaded is off.
+        assert transcribe_mod._MODEL_CACHE == {}
+
+    def test_cleanup_retains_resident_model(self, clear_model_cache):
+        with patch.object(
+            transcribe_mod, "_create_whisper_model", side_effect=lambda *a: object()
+        ):
+            stage = Transcribe(config=self._local_cfg(keep_loaded=True))
+            assert stage._model_ready.wait(timeout=10)
+
+            assert len(transcribe_mod._MODEL_CACHE) == 1
+            cached = next(iter(transcribe_mod._MODEL_CACHE.values()))
+
+            stage.cleanup()
+
+        # Stage drops its own reference, but the cache keeps the model resident.
+        assert stage._preloaded_model is None
+        assert len(transcribe_mod._MODEL_CACHE) == 1
+        assert next(iter(transcribe_mod._MODEL_CACHE.values())) is cached
+
+    def test_cleanup_evicts_non_resident_model(self, clear_model_cache):
+        with patch.object(
+            transcribe_mod, "_create_whisper_model", side_effect=lambda *a: object()
+        ):
+            stage = Transcribe(config=self._local_cfg(keep_loaded=False))
+            assert stage._model_ready.wait(timeout=10)
+            assert stage._preloaded_model is not None
+
+            stage.cleanup()
+
+        assert stage._preloaded_model is None
+        assert transcribe_mod._MODEL_CACHE == {}

--- a/tests/test_transcribe_keep_loaded.py
+++ b/tests/test_transcribe_keep_loaded.py
@@ -18,10 +18,12 @@ from voicetype.pipeline.stages.transcribe import (
 
 @pytest.fixture
 def clear_model_cache():
-    """Ensure the module-level resident-model cache is empty around each test."""
+    """Reset the module-level cache and runtime override around each test."""
     transcribe_mod._MODEL_CACHE.clear()
+    transcribe_mod._keep_loaded_override = None
     yield
     transcribe_mod._MODEL_CACHE.clear()
+    transcribe_mod._keep_loaded_override = None
 
 
 class TestKeepLoadedConfig:
@@ -136,3 +138,64 @@ class TestResidentModelCache:
 
         assert stage._preloaded_model is None
         assert transcribe_mod._MODEL_CACHE == {}
+
+
+class TestRuntimeKeepLoadedToggle:
+    """The keep_loaded state can be flipped at runtime (e.g. from the tray menu)."""
+
+    def test_resolve_follows_config_when_no_override(self, clear_model_cache):
+        assert transcribe_mod.is_keep_loaded() is False
+        assert transcribe_mod._resolve_keep_loaded(True) is True
+        assert transcribe_mod._resolve_keep_loaded(False) is False
+
+    def test_init_seeds_once(self, clear_model_cache):
+        transcribe_mod.init_keep_loaded(True)
+        assert transcribe_mod.is_keep_loaded() is True
+        # A second init does not override an already-set value.
+        transcribe_mod.init_keep_loaded(False)
+        assert transcribe_mod.is_keep_loaded() is True
+
+    def test_override_wins_over_config(self, clear_model_cache):
+        transcribe_mod.set_keep_loaded(True)
+        assert transcribe_mod.is_keep_loaded() is True
+        assert transcribe_mod._resolve_keep_loaded(False) is True  # config says off
+
+        transcribe_mod.set_keep_loaded(False)
+        assert transcribe_mod.is_keep_loaded() is False
+        assert transcribe_mod._resolve_keep_loaded(True) is False  # config says on
+
+    def test_disabling_evicts_resident_models(self, clear_model_cache):
+        transcribe_mod._MODEL_CACHE[("tiny", "cuda", "float16")] = object()
+        transcribe_mod.set_keep_loaded(False)
+        assert transcribe_mod._MODEL_CACHE == {}
+
+    def test_clear_resident_models(self, clear_model_cache):
+        transcribe_mod._MODEL_CACHE[("tiny", "cpu", "int8")] = object()
+        transcribe_mod.clear_resident_models()
+        assert transcribe_mod._MODEL_CACHE == {}
+
+    def test_runtime_override_controls_caching(self, clear_model_cache):
+        """A stage whose config says keep_loaded=False still caches when the
+        runtime override is on (mirrors toggling the tray item on)."""
+        transcribe_mod.set_keep_loaded(True)
+        created = []
+        with patch.object(
+            transcribe_mod,
+            "_create_whisper_model",
+            side_effect=lambda *a: created.append(object()) or created[-1],
+        ):
+            cfg = {
+                "runtime": {
+                    "provider": "local",
+                    "model": "tiny",
+                    "device": "cpu",
+                    "keep_loaded": False,
+                }
+            }
+            s1 = Transcribe(config=cfg)
+            assert s1._model_ready.wait(timeout=10)
+            s2 = Transcribe(config=cfg)
+            assert s2._model_ready.wait(timeout=10)
+
+        assert len(created) == 1
+        assert s1._preloaded_model is s2._preloaded_model

--- a/voicetype/pipeline/stages/transcribe.py
+++ b/voicetype/pipeline/stages/transcribe.py
@@ -126,6 +126,56 @@ def _get_or_create_whisper_model(
         return model
 
 
+def clear_resident_models() -> None:
+    """Evict all resident models from the cache and free their memory."""
+    with _MODEL_CACHE_LOCK:
+        had_models = bool(_MODEL_CACHE)
+        _MODEL_CACHE.clear()
+    if had_models:
+        logger.info("Evicted resident Whisper model(s) from cache")
+        import gc
+
+        gc.collect()
+
+
+# Runtime override for keep_loaded, controllable without a restart (e.g. from the
+# tray menu). ``None`` means "follow each runtime's configured value"; once set to
+# a bool it overrides the config for all local runtimes.
+_keep_loaded_override: Optional[bool] = None
+_keep_loaded_override_lock = threading.Lock()
+
+
+def init_keep_loaded(enabled: bool) -> None:
+    """Initialize the runtime keep_loaded state from config (no-op if already set)."""
+    global _keep_loaded_override
+    with _keep_loaded_override_lock:
+        if _keep_loaded_override is None:
+            _keep_loaded_override = enabled
+
+
+def set_keep_loaded(enabled: bool) -> None:
+    """Override keep_loaded at runtime. Disabling evicts any resident models."""
+    global _keep_loaded_override
+    with _keep_loaded_override_lock:
+        _keep_loaded_override = enabled
+    if not enabled:
+        clear_resident_models()
+
+
+def is_keep_loaded() -> bool:
+    """Return the current effective keep_loaded state (False if uninitialized)."""
+    with _keep_loaded_override_lock:
+        return bool(_keep_loaded_override)
+
+
+def _resolve_keep_loaded(config_value: bool) -> bool:
+    """Resolve effective keep_loaded: the runtime override if set, else config."""
+    with _keep_loaded_override_lock:
+        if _keep_loaded_override is None:
+            return config_value
+        return _keep_loaded_override
+
+
 # =============================================================================
 # Runtime Models - Unified STT runtime configurations
 # =============================================================================
@@ -276,8 +326,9 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
             model_path = str(bundled_path) if bundled_path else runtime.model
             models_dir = self.cfg.download_root or str(get_app_data_dir() / "models")
             compute_type = "float16" if runtime.device == "cuda" else "int8"
+            keep_loaded = _resolve_keep_loaded(runtime.keep_loaded)
 
-            if runtime.keep_loaded:
+            if keep_loaded:
                 logger.info(
                     f"Loading resident Whisper model '{runtime.model}' on "
                     f"{runtime.device} (kept loaded between requests)..."
@@ -291,7 +342,7 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
                 runtime.device,
                 compute_type,
                 models_dir,
-                runtime.keep_loaded,
+                keep_loaded,
             )
             logger.info("Whisper model preload complete")
         except Exception as e:
@@ -316,7 +367,9 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
             return
 
         runtime = self.cfg.runtime
-        if isinstance(runtime, LocalSTTRuntime) and runtime.keep_loaded:
+        if isinstance(runtime, LocalSTTRuntime) and _resolve_keep_loaded(
+            runtime.keep_loaded
+        ):
             # Model stays resident in _MODEL_CACHE; just drop our reference.
             self._preloaded_model = None
             return
@@ -388,7 +441,7 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
                     device,
                     compute_type,
                     models_dir,
-                    runtime.keep_loaded,
+                    _resolve_keep_loaded(runtime.keep_loaded),
                 )
             except Exception:
                 if device == "cuda":

--- a/voicetype/pipeline/stages/transcribe.py
+++ b/voicetype/pipeline/stages/transcribe.py
@@ -73,6 +73,60 @@ def _cuda_synchronize():
 
 
 # =============================================================================
+# Resident model cache
+# =============================================================================
+#
+# When a runtime is configured with ``keep_loaded=True`` the constructed
+# WhisperModel is stored here, keyed by (model_path, device, compute_type), and
+# reused across pipeline runs instead of being reloaded (and freed) on every
+# hotkey press. This avoids the multi-second reload that occurs when the GPU has
+# idled into a low-power state. Access is guarded by a lock because the model is
+# loaded from a background preload thread.
+_MODEL_CACHE: dict[tuple[str, str, str], object] = {}
+_MODEL_CACHE_LOCK = threading.Lock()
+
+
+def _create_whisper_model(
+    model_path: str, device: str, compute_type: str, models_dir: str
+):
+    """Construct a faster-whisper WhisperModel (no caching)."""
+    from faster_whisper import WhisperModel
+
+    return WhisperModel(
+        model_path,
+        device=device,
+        compute_type=compute_type,
+        download_root=models_dir,
+    )
+
+
+def _get_or_create_whisper_model(
+    model_path: str,
+    device: str,
+    compute_type: str,
+    models_dir: str,
+    keep_loaded: bool,
+):
+    """Return a WhisperModel, reusing a cached resident instance if enabled.
+
+    When ``keep_loaded`` is False the model is constructed fresh on every call
+    (the historical behavior). When True, the model is loaded once per
+    (model_path, device, compute_type) and reused for the lifetime of the
+    process.
+    """
+    if not keep_loaded:
+        return _create_whisper_model(model_path, device, compute_type, models_dir)
+
+    key = (model_path, device, compute_type)
+    with _MODEL_CACHE_LOCK:
+        model = _MODEL_CACHE.get(key)
+        if model is None:
+            model = _create_whisper_model(model_path, device, compute_type, models_dir)
+            _MODEL_CACHE[key] = model
+        return model
+
+
+# =============================================================================
 # Runtime Models - Unified STT runtime configurations
 # =============================================================================
 
@@ -91,6 +145,16 @@ class LocalSTTRuntime(BaseModel):
     )
     device: Literal["cuda", "cpu"] = Field(
         default="cpu", description="Device for inference"
+    )
+    keep_loaded: bool = Field(
+        default=False,
+        description=(
+            "Keep the model resident in memory/VRAM between transcriptions instead "
+            "of reloading it on every request. Eliminates per-request model load "
+            "latency (which can be many seconds on a GPU that has idled into a "
+            "low-power state) at the cost of holding the model's memory for the "
+            "lifetime of the process."
+        ),
     )
 
 
@@ -206,8 +270,6 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
     def _preload_model(self):
         """Load the WhisperModel in a background thread."""
         try:
-            from faster_whisper import WhisperModel
-
             runtime = self.cfg.runtime
 
             bundled_path = get_bundled_model_path(runtime.model)
@@ -215,14 +277,21 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
             models_dir = self.cfg.download_root or str(get_app_data_dir() / "models")
             compute_type = "float16" if runtime.device == "cuda" else "int8"
 
-            logger.info(
-                f"Preloading Whisper model '{runtime.model}' on {runtime.device}..."
-            )
-            self._preloaded_model = WhisperModel(
+            if runtime.keep_loaded:
+                logger.info(
+                    f"Loading resident Whisper model '{runtime.model}' on "
+                    f"{runtime.device} (kept loaded between requests)..."
+                )
+            else:
+                logger.info(
+                    f"Preloading Whisper model '{runtime.model}' on {runtime.device}..."
+                )
+            self._preloaded_model = _get_or_create_whisper_model(
                 model_path,
-                device=runtime.device,
-                compute_type=compute_type,
-                download_root=models_dir,
+                runtime.device,
+                compute_type,
+                models_dir,
+                runtime.keep_loaded,
             )
             logger.info("Whisper model preload complete")
         except Exception as e:
@@ -237,17 +306,30 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
             self._model_ready.set()
 
     def cleanup(self):
-        """Release the preloaded model to free GPU/CPU memory."""
-        if self._preloaded_model is not None:
-            logger.debug("Releasing preloaded Whisper model")
-            del self._preloaded_model
+        """Release the preloaded model to free GPU/CPU memory.
+
+        When the runtime is configured with ``keep_loaded=True`` the model is
+        retained in the module-level cache for reuse on subsequent runs, so we
+        only drop this stage's reference without freeing the underlying memory.
+        """
+        if self._preloaded_model is None:
+            return
+
+        runtime = self.cfg.runtime
+        if isinstance(runtime, LocalSTTRuntime) and runtime.keep_loaded:
+            # Model stays resident in _MODEL_CACHE; just drop our reference.
             self._preloaded_model = None
+            return
 
-            # Force garbage collection so CTranslate2's C++ destructor runs
-            # immediately, releasing CUDA memory back to the GPU.
-            import gc
+        logger.debug("Releasing preloaded Whisper model")
+        del self._preloaded_model
+        self._preloaded_model = None
 
-            gc.collect()
+        # Force garbage collection so CTranslate2's C++ destructor runs
+        # immediately, releasing CUDA memory back to the GPU.
+        import gc
+
+        gc.collect()
 
     def _get_runtime_description(self, runtime: STTRuntime) -> str:
         """Get a human-readable description of a runtime configuration."""
@@ -291,8 +373,6 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
                 logger.warning("Preload failed, loading model inline")
 
         if whisper_model is None:
-            from faster_whisper import WhisperModel
-
             model = runtime.model
             device = runtime.device
 
@@ -303,11 +383,12 @@ class Transcribe(PipelineStage[Optional[str], Optional[str]]):
             compute_type = "float16" if device == "cuda" else "int8"
 
             try:
-                whisper_model = WhisperModel(
+                whisper_model = _get_or_create_whisper_model(
                     model_path,
-                    device=device,
-                    compute_type=compute_type,
-                    download_root=models_dir,
+                    device,
+                    compute_type,
+                    models_dir,
+                    runtime.keep_loaded,
                 )
             except Exception:
                 if device == "cuda":

--- a/voicetype/pipeline/stages/transcribe.py
+++ b/voicetype/pipeline/stages/transcribe.py
@@ -89,15 +89,38 @@ _MODEL_CACHE_LOCK = threading.Lock()
 def _create_whisper_model(
     model_path: str, device: str, compute_type: str, models_dir: str
 ):
-    """Construct a faster-whisper WhisperModel (no caching)."""
+    """Construct a faster-whisper WhisperModel, preferring the local cache.
+
+    faster-whisper resolves a model given by name (e.g. "large-v3-turbo")
+    through the HuggingFace Hub, which makes a network request on *every* load
+    to validate the cached copy. If the Hub is slow or unreachable, that request
+    blocks until it times out (~10s) before falling back to the local cache,
+    adding a large, seemingly random delay to transcription. To avoid it we load
+    with ``local_files_only=True`` first (no network when the model is already
+    downloaded) and only reach the Hub if the model isn't present locally.
+    """
     from faster_whisper import WhisperModel
 
-    return WhisperModel(
-        model_path,
+    try:
+        from huggingface_hub.errors import LocalEntryNotFoundError
+    except ImportError:  # pragma: no cover - older huggingface_hub layout
+        from huggingface_hub.utils import LocalEntryNotFoundError
+
+    kwargs = dict(
         device=device,
         compute_type=compute_type,
         download_root=models_dir,
     )
+    try:
+        # Already downloaded: load straight from cache, no Hub round-trip.
+        return WhisperModel(model_path, local_files_only=True, **kwargs)
+    except LocalEntryNotFoundError:
+        # Not cached locally (e.g. first run) -- allow the network download.
+        logger.info(
+            f"Model '{model_path}' not in local cache; "
+            f"downloading from the HuggingFace Hub..."
+        )
+        return WhisperModel(model_path, local_files_only=False, **kwargs)
 
 
 def _get_or_create_whisper_model(

--- a/voicetype/trayicon.py
+++ b/voicetype/trayicon.py
@@ -235,6 +235,45 @@ def _build_menu(ctx: AppContext, icon: pystray.Icon) -> Menu:
     if hasattr(ctx, "telemetry_enabled") and ctx.telemetry_enabled:
         menu_items.append(Item("Open Traces", _open_traces))
 
+    # Add "Keep model loaded" toggle if a local transcription runtime is in use.
+    # Lets the user keep the Whisper model resident in VRAM (no reload per press)
+    # or free it, at runtime, without editing settings.toml and restarting.
+    local_keep_loaded_cfg = None
+    if ctx.pipeline_manager:
+        for pipeline_cfg in ctx.pipeline_manager.pipelines.values():
+            if not pipeline_cfg.enabled:
+                continue
+            for stage_cfg in pipeline_cfg.stages:
+                if stage_cfg.get("stage") != "Transcribe":
+                    continue
+                runtime_cfg = stage_cfg.get("runtime") or {}
+                if runtime_cfg.get("provider", "local") == "local":
+                    local_keep_loaded_cfg = bool(runtime_cfg.get("keep_loaded", False))
+                    break
+            if local_keep_loaded_cfg is not None:
+                break
+
+    if local_keep_loaded_cfg is not None:
+        from voicetype.pipeline.stages import transcribe as _transcribe
+
+        # Seed runtime state from config the first time the menu is built.
+        _transcribe.init_keep_loaded(local_keep_loaded_cfg)
+
+        def _toggle_keep_loaded(_icon: pystray._base.Icon, _item: Item):
+            new_value = not _transcribe.is_keep_loaded()
+            _transcribe.set_keep_loaded(new_value)
+            logger.info(f"'Keep model loaded' toggled to {new_value} via tray menu")
+            _icon.menu = _build_menu(ctx, icon)
+            _icon.update_menu()
+
+        menu_items.append(
+            Item(
+                "Keep model loaded",
+                _toggle_keep_loaded,
+                checked=lambda _item: _transcribe.is_keep_loaded(),
+            )
+        )
+
     # Discover menu items contributed by pipeline stages
     if ctx.pipeline_manager:
         from voicetype.pipeline.stage_registry import STAGE_REGISTRY


### PR DESCRIPTION
## Summary

Speeds up local Whisper model loading in two complementary ways: it skips the HuggingFace Hub network check when the model is already cached, and adds an option to keep the model resident so it isn't reloaded between requests.

## Background

faster-whisper resolves a model given by *name* (e.g. `large-v3-turbo`) through `huggingface_hub`, which makes a network request **on every load** to validate the cached copy (`local_files_only=False` by default). When the Hub is slow or unreachable, that request blocks until it times out (~10s) and only then falls back to the already-downloaded local copy — so a load that should be near-instant for a cached model can intermittently take several seconds.

Loading an already-cached model, with vs. without the Hub check (warm process, same cached model):
```
local_files_only=False (hits Hub)   -> ~10.8s
local_files_only=True  (no network) -> ~0.7-1.1s
```

## Changes

1. **Skip the Hub for cached models** (benefits every load): `_create_whisper_model` now loads with `local_files_only=True` first and only reaches the network if the model isn't present locally (`LocalEntryNotFoundError`). CUDA/construction errors propagate from the first attempt — no spurious network retry.

2. **`keep_loaded` option** on `LocalSTTRuntime` (default `false`): keep the model resident in VRAM/RAM across requests instead of reloading and freeing it each time, via a module-level cache keyed by `(model_path, device, compute_type)`. Removes per-request load overhead entirely.

3. **"Keep model loaded" tray toggle**: flip `keep_loaded` at runtime (no settings edit or restart). Disabling evicts resident models to free VRAM immediately. Shown only when a local transcription runtime is in use.

Enable the resident model via:
```toml
[stage_configs.Transcribe.runtime]
provider = "local"
model = "large-v3-turbo"
device = "cuda"
keep_loaded = true
```

## Tests

`tests/test_transcribe_keep_loaded.py` (mock-based, no GPU): config default/override, load-once-and-reuse, cleanup retain vs. evict, runtime toggle/eviction, and the `local_files_only` cache-first / download-fallback / error-propagation behavior. 34 pass; pre-commit (black/ruff/isort/typos) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
